### PR TITLE
make the page always load in firefox

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+  <!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="utf-8">
@@ -25,6 +25,8 @@
       }
       body {
         opacity: 0;
+      }
+      body.loading {
         transition: opacity 0.1s linear;
       }
       body.loaded {
@@ -89,7 +91,7 @@
 
   </head>
 
-  <body id="body">
+  <body id="body" class="loading">
     <div id="header">
 
       <img id="logo" src="node-forward.png">
@@ -138,6 +140,11 @@
     document.addEventListener('DOMContentLoaded' , function() {
       // fade in ;D
       document.getElementById('body').classList.add('loaded')
+
+      setTimeout(function(){
+        document.getElementById('body').classList.remove('loading')
+      }, 100)
+
 
       // get awesome splash texts of awesomeness.
       // using superagent because it's node-like and cool.


### PR DESCRIPTION
Firefox does not like the transition -- sometimes the page is entirely blank until you refresh, sometimes the page is partially opaque until you refresh.

Not sure what the best solution is here to keep the fade effect, so I moved it to another class that gets removed eventually which makes Firefox MUCH happier.

Here's what I would get 50% of the time trying to access nodeforward:
![screen shot 2014-10-30 at 10 44 21 am](https://cloud.githubusercontent.com/assets/193412/4845392/14a7080c-6044-11e4-9ac4-2bb2f91c7b09.png)
